### PR TITLE
test: chromium installation only

### DIFF
--- a/.github/workflows/sast-actions.yml
+++ b/.github/workflows/sast-actions.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions: {}
+
 jobs:
   analysis:
     runs-on: ubuntu-latest

--- a/tooling/playwright/package.json
+++ b/tooling/playwright/package.json
@@ -6,7 +6,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "browsers": "pnpm playwright install",
+    "browsers": "pnpm playwright install --with-deps --only-headless chromium",
     "e2e": "pnpm bddgen && pnpm playwright test --project=chromium"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to explicitly set default permissions to none for improved security.
  * Modified Playwright browser installation script to install only headless Chromium with dependencies, optimising test environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->