### PR TITLE
build(deps): allow cool-down window vs supply chain attacks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     "schedule:nonOfficeHours",
     ":gitSignOff"
   ],
+  "internalChecksFilter": "strict",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "groupName": "types-and-linters",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Tightened dependency update policy with stricter internal checks and a three-day minimum release age before proposing updates. This reduces risk from premature or unstable releases while retaining existing automation. No existing rules or structures were changed; behaviour is unchanged aside from the added safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->